### PR TITLE
shorten repo name and publish it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,8 @@
 # Pomerium Javascript SDK
-
-Eventually will work with both Node and Browsers. Initially concentrating on Browsers.
+An easy way to verify and parse Pomerium's JWT.
 
 Getting Started
-
-```yarn```
-
-```yarn link```
-
-Then in the repo you want to use it:
-
-```yarn link @pomerium/pomerium-js-sdk```
+```yarn add @pomerium/js-sdk```
 
 Basic Usage:
 

--- a/examples/express/index.js
+++ b/examples/express/index.js
@@ -1,5 +1,5 @@
 const express = require("express");
-const { PomeriumVerifier } = require('../../lib/cjs/verifier');
+const { PomeriumVerifier } = require('@pomerium/js-sdk');
 const app = express();
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; //just for dev

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "private": null,
   "dependencies": {
+    "@pomerium/js-sdk": "^1.0.0",
     "express": "^4.18.2"
   }
 }

--- a/examples/express/yarn.lock
+++ b/examples/express/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@pomerium/js-sdk@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@pomerium/js-sdk/-/js-sdk-1.0.0.tgz#6f90ef763d8bd6193183180d476aee63587be3ff"
+  integrity sha512-XcAgU4KssZdBZ3byfWOIGQrF6jtHW7S/BpJRpnB5gnchYjSlsJrrrLDqr4JM1T6q1qC/L7KUnqKTXbsYMGjCMA==
+  dependencies:
+    jose "^4.10.4"
+
 accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -218,6 +225,11 @@ ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+
+jose@^4.10.4:
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.11.1.tgz#8f7443549befe5bddcf4bae664a9cbc1a62da4fa"
+  integrity sha512-YRv4Tk/Wlug8qicwqFNFVEZSdbROCHRAC6qu/i0dyNKr5JQdoa2pIGoS04lLO/jXQX7Z9omoNewYIVIxqZBd9Q==
 
 media-typer@0.3.0:
   version "0.3.0"

--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@pomerium/js-sdk": "^1.0.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/examples/react-app/src/App.js
+++ b/examples/react-app/src/App.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { PomeriumVerifier, signOut } from '@pomerium/pomerium-js-sdk';
+import { PomeriumVerifier, signOut } from '@pomerium/js-sdk';
 
 function App() {
 

--- a/examples/react-app/yarn.lock
+++ b/examples/react-app/yarn.lock
@@ -1572,6 +1572,13 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
+"@pomerium/js-sdk@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@pomerium/js-sdk/-/js-sdk-1.0.0.tgz#6f90ef763d8bd6193183180d476aee63587be3ff"
+  integrity sha512-XcAgU4KssZdBZ3byfWOIGQrF6jtHW7S/BpJRpnB5gnchYjSlsJrrrLDqr4JM1T6q1qC/L7KUnqKTXbsYMGjCMA==
+  dependencies:
+    jose "^4.10.4"
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
@@ -5792,6 +5799,11 @@ jest@^27.4.3:
     "@jest/core" "^27.5.1"
     import-local "^3.0.2"
     jest-cli "^27.5.1"
+
+jose@^4.10.4:
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.11.1.tgz#8f7443549befe5bddcf4bae664a9cbc1a62da4fa"
+  integrity sha512-YRv4Tk/Wlug8qicwqFNFVEZSdbROCHRAC6qu/i0dyNKr5JQdoa2pIGoS04lLO/jXQX7Z9omoNewYIVIxqZBd9Q==
 
 js-sdsl@^4.1.4:
   version "4.1.5"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pomerium/pomerium-js-sdk",
+  "name": "@pomerium/js-sdk",
   "version": "1.0.0",
   "description": "Verify and Parse Pomerium JWTs",
   "exports": {
@@ -38,7 +38,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/pomerium/pomerium-js-sdk.git"
+    "url": "https://github.com/pomerium/js-sdk.git"
   },
   "keywords": [
     "zero trust",


### PR DESCRIPTION
Shorten the repo name for less typing.
Publish it.
Also use published version for the tests. 
fixes https://github.com/pomerium/pomerium-console/issues/2796