### PR TITLE
js-sdk/ci: disable dependabot for npm

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,2 @@
 version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 50
+updates: []


### PR DESCRIPTION
For https://github.com/pomerium/internal/issues/1594