### PR TITLE
fix expired check

### DIFF
--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -75,6 +75,6 @@ export class PomeriumVerifier {
       return false;
     }
     const currentDateInSeconds = new Date().getTime() / 1000;
-    return exp < (currentDateInSeconds + this.expirationBuffer)
+    return currentDateInSeconds < (exp + this.expirationBuffer);
   }
 }


### PR DESCRIPTION
This fixes the expires check. As it was, setting expirationBuffer to a positive number caused isLoggedIn() to incorrectly throw that that JWT was expired.

Fixes #33